### PR TITLE
Fixed the problem of generating JavaScript code for import blocks' parameters. fixes #4

### DIFF
--- a/google-blockly-82871b3/generators/python/import.js
+++ b/google-blockly-82871b3/generators/python/import.js
@@ -4,8 +4,8 @@ Blockly.Python['import_return'] = function (block) {
 
   for (let i = 0; i < block.argsCount_; i++) {
     let noConnectionValue = "None";
-    args[i] = Blockly.JavaScript.valueToCode(block, "ARG" + i,
-        Blockly.JavaScript.ORDER_ATOMIC) || noConnectionValue;
+    args[i] = Blockly.Python.valueToCode(block, "ARG" + i,
+        Blockly.Python.ORDER_ATOMIC) || noConnectionValue;
   }
 
   let code = funcName + "(" + args.join(", ") + ")";
@@ -18,8 +18,8 @@ Blockly.Python['import_statement'] = function (block) {
 
   for (let i = 0; i < block.argsCount_; i++) {
     let noConnectionValue = "None";
-    args[i] = Blockly.JavaScript.valueToCode(block, "ARG" + i,
-        Blockly.JavaScript.ORDER_ATOMIC) || noConnectionValue;
+    args[i] = Blockly.Python.valueToCode(block, "ARG" + i,
+        Blockly.Python.ORDER_ATOMIC) || noConnectionValue;
   }
 
   let code = funcName + "(" + args.join(", ") + ")\n";


### PR DESCRIPTION
#4 

- Fixed using Blockly.JavaScript on Blockly.Python for import blocks