### PR TITLE
Fixed toolbox displaying outdated block lists when it is open. (Closes #3)

### DIFF
--- a/google-blockly-82871b3/tests/playground.html
+++ b/google-blockly-82871b3/tests/playground.html
@@ -319,7 +319,17 @@ function myImport() {
       childrenCount--;
     }
   }
+
+  collapseToolbox();
   workspace.updateToolbox(document.getElementById("toolbox-categories"));
+}
+
+function collapseToolbox() {
+  let tree = workspace.getToolbox().tree_;
+
+  if (tree) {
+    tree.setSelectedItem(null);
+  }
 }
 
 function toXml() {
@@ -547,6 +557,8 @@ h1 {
     <input type="button" value="Insert test XML" onclick="insertTestXml()">
 
     <input type="button" value="My import" onclick="myImport()">
+
+    <input type="button" value="Toolbox Collapse" onclick="collapseToolbox()">
     <br>
     <input type="button" value="Export to XML" onclick="toXml()">
     &nbsp;


### PR DESCRIPTION
- Added a function to auto-close Library toolbox when importing import-blocks
- Added a testing button for closing the toolbox